### PR TITLE
Add virtualenv support and pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ requests = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.9"
+python_version = "3"

--- a/check_gude.py
+++ b/check_gude.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+################################################################################
+# This requirements file has been automatically generated from `Pipfile` with
+# `pipenv-to-requirements`
+#
+#
+# This has been done to maintain backward compatibility with tools and services
+# that do not support `Pipfile` yet.
+#
+# Do NOT edit it directly, use `pipenv install [-d]` to modify `Pipfile` and
+# `Pipfile.lock` and then regenerate `requirements*.txt`.
+################################################################################
+
+requests


### PR DESCRIPTION
This PR changes the interpreter used to run the script to env, so any python interpreter can be used, not only the system one. This allows the script to be used in a virtualenv or from Pipenv.

I've also added a requirements.txt / Pipfile for the dependency.